### PR TITLE
chore: update path to .proto file in README.md

### DIFF
--- a/grpc_k8s/README.md
+++ b/grpc_k8s/README.md
@@ -50,7 +50,7 @@ definitions to create a client implementation from the spec. When running from t
 command to connect to the server would be:
 
 ```shell script
-grpcc -i --proto cmd/protocol/sentence.proto --address <ADDRESS_GOES_HERE>:9001
+grpcc -i --proto protocol/sentence.proto --address <ADDRESS_GOES_HERE>:9001
 ```
 
 Once connected, the following command can be used to test the unary endpoint.


### PR DESCRIPTION
While working on my solution, I found that the path to the .proto file was incorrect.

Path in README:
````
dbilleci at danno62 in ~/Development/covrco/candidate-exercises/grpc_k8s on master
$ grpcc --proto cmd/protocol/sentence.proto --address grpc.billeci.com:9001
Error: Could not load file "[object Object]"
    at Object.load (/usr/local/lib/node_modules/grpcc/node_modules/grpc/index.js:148:11)
    at Object.deprecated [as load] (internal/util.js:67:15)
    at createClient (/usr/local/lib/node_modules/grpcc/lib/index.js:57:21)
    at Object.<anonymous> (/usr/local/lib/node_modules/grpcc/bin/grpcc.js:35:3)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
````

Updated path:
````
dbilleci at danno62 in ~/Development/covrco/candidate-exercises/grpc_k8s on master
$ grpcc --proto protocol/sentence.proto --address grpc.billeci.com:9001

Connecting to covr.grpc.sentence.Sentence on grpc.billeci.com:9001. Available globals:

  client - the client connection to Sentence
    splitUnary (SplitSentenceRequest, callback) returns SplitSentenceUnaryResponse
    splitStream (SplitSentenceRequest, callback) returns SplitSentenceStreamResponse

  printReply - function to easily print a unary call reply (alias: pr)
  streamReply - function to easily print stream call replies (alias: sr)
  createMetadata - convert JS objects into grpc metadata instances (alias: cm)
  printMetadata - function to easily print a unary call's metadata (alias: pm)

Sentence@grpc.billeci.com:9001> (node:67708) DeprecationWarning: grpc.load: Use the @grpc/proto-loader module with grpc.loadPackageDefinition instead

Sentence@grpc.billeci.com:9001> client.SplitStream({ "sentence": "This, the best of all sentences." }).on('data', streamReply).on('status', streamReply)
EventEmitter {}
Sentence@grpc.billeci.com:9001> (node:67708) [DEP0079] DeprecationWarning: Custom inspection function on Objects via .inspect() is deprecated

{
  "word": "this"
}
Sentence@grpc.billeci.com:9001> 
{
  "word": "the"
}
Sentence@grpc.billeci.com:9001> 
{
  "word": "best"
}
Sentence@grpc.billeci.com:9001> 
{
  "word": "of"
}
Sentence@grpc.billeci.com:9001> 
{
  "word": "all"
}
Sentence@grpc.billeci.com:9001> 
{
  "word": "sentences"
}
Sentence@grpc.billeci.com:9001> 
{
  "code": 0,
  "details": "",
  "metadata": {
    "_internal_repr": {},
    "flags": 0
  }
}
Sentence@grpc.billeci.com:9001> 
````